### PR TITLE
fix(receiver): harden capture receiver against path injection (v0.2.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "l3a0",
   "description": "l3a0's Claude Code skills. Currently: kindle-highlights — extract a book's Kindle highlights into one verbatim, location-cited Markdown file, recovering everything Amazon's export limit truncates or hides.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "l3a0",
     "url": "https://baowebdev.substack.com"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ gotcha in the skill was earned by real debugging across those runs.
 The build story — why the export limit exists, the three unlocks that beat it, and what a
 library of exports becomes — is written up in
 [How to Take Back Your Kindle Highlights](blog/how-to-take-back-your-kindle-highlights.md),
-also published on [Substack](https://baowebdev.substack.com).
+also published on [Substack](https://baowebdev.substack.com/p/how-to-take-back-your-kindle-highlights).
 
 **Scope:** this exports *your own* highlights from *your own* Amazon account, by driving your
 own logged-in browser session and reading files the Kindle app stores on your Mac. The output

--- a/skills/kindle-highlights/scripts/receiver.py
+++ b/skills/kindle-highlights/scripts/receiver.py
@@ -27,13 +27,22 @@ class H(http.server.BaseHTTPRequestHandler):
     def do_POST(self):
         u = urlparse(self.path)
         q = parse_qs(u.query)
-        name = re.sub(r"[^A-Za-z0-9_.-]", "_", (q.get("name") or ["unnamed"])[0])
+        # basename + allowlist strip any path components from the client-supplied name
+        name = re.sub(r"[^A-Za-z0-9_.-]", "_", os.path.basename((q.get("name") or ["unnamed"])[0]))
         n = int(self.headers.get("Content-Length", 0))
         body = self.rfile.read(n)
         if u.path == "/page":
             out = os.path.join(PAGES, name if name.endswith(".png") else name + ".png")
         else:
             out = os.path.join(PAGES, name if name.endswith(".json") else name + ".json")
+        # resolve and confirm the final path stays inside PAGES (path-injection guard)
+        out = os.path.realpath(out)
+        if not out.startswith(os.path.realpath(PAGES) + os.sep):
+            self.send_response(400)
+            self._cors()
+            self.end_headers()
+            self.wfile.write(b"bad name")
+            return
         with open(out, "wb") as f:
             f.write(body)
         self.send_response(200)


### PR DESCRIPTION
## What

Resolves **CodeQL alert #1** (`py/path-injection`, High — `skills/kindle-highlights/scripts/receiver.py:37`), where the client-supplied `?name=` query parameter flowed into the output path of the localhost capture receiver.

The write path now has three layers:

1. `os.path.basename()` strips any directory components from the supplied name.
2. The existing character allowlist (`[^A-Za-z0-9_.-]` → `_`) still replaces path separators.
3. New: the final path is resolved with `os.path.realpath` and must sit inside `pages/`, else the request gets a 400. This prefix-check-after-normalization is the sanitizer pattern CodeQL's query recognizes, so the alert closes on the next `main` scan after merge.

Also in this PR:

- README: the kindle-highlights section now links the actual Substack post (`/p/how-to-take-back-your-kindle-highlights`) instead of the publication homepage.
- `plugin.json`: 0.2.1 → 0.2.2, since a skill script changed.

## Verification

Ran the patched receiver live: normal skill traffic (`?name=test_geo`, `?name=c01_s00.png`) saves exactly as before; three traversal payloads (`../../evil`, URL-encoded `%2e%2e%2f` variants) all landed as harmless sanitized filenames **inside** `pages/`, with nothing written outside the directory.

## Context for reviewers

Practical exposure was already near-zero — the old allowlist replaced path separators, and the server binds to `127.0.0.1` only for the duration of an extraction run. This change makes the safety structural rather than incidental, and legible to the scanner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)