### PR TITLE
ci: add HOL plugin-scanner security workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/plugin-security-scan.yml
+++ b/.github/workflows/plugin-security-scan.yml
@@ -1,0 +1,16 @@
+name: Plugin Security Scan
+on: [pull_request, push]
+permissions:
+  contents: read
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: hashgraph-online/ai-plugin-scanner-action@55616c962cf86368423f7673b2ecdfdbe613d1af # v1.2.515
+        with:
+          plugin_dir: "."
+          min_score: 80
+          fail_on_severity: high

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release of the `l3a0` plugin is supported. Update with
+`claude plugin update l3a0@l3a0` before reporting an issue.
+
+| Version | Supported |
+| ------- | --------- |
+| 0.2.x (latest) | ✅ |
+| < 0.2 | ❌ |
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities privately via
+[GitHub's private vulnerability reporting](https://github.com/l3a0/claude-plugins/security/advisories/new)
+for this repository. If that page is unavailable, open a
+[GitHub issue](https://github.com/l3a0/claude-plugins/issues/new) asking for a
+private contact channel — do not include exploit details in the public issue.
+
+You can expect an acknowledgement within a week. Please allow a fix to land
+before public disclosure.
+
+## Scope
+
+The skills in this repo run locally and drive the user's own logged-in
+browser session and local app data (see each skill's README/SKILL.md for its
+exact access). Reports of particular interest:
+
+- Anything that could exfiltrate highlight data or credentials off-machine
+  (the pipeline is designed to be local-only; the capture receiver binds
+  `127.0.0.1` and validates paths).
+- Path injection or command injection via scraped page content or filenames.
+- Prompt-injection vectors in skill instructions that could cause unintended
+  actions.


### PR DESCRIPTION
Adds the scanner CI workflow recommended by [awesome-ai-plugins' SCANNER_GUIDE.md](https://github.com/hashgraph-online/awesome-ai-plugins/blob/main/SCANNER_GUIDE.md), following up on hashgraph-online/awesome-ai-plugins#151 — listings that run scanner CI keep the full trust score in the HOL registry (without it, a 10% reduction).

## What it does

Runs the HOL plugin scanner on every push and PR, failing if the score drops below 80 or any high/critical finding appears. HOL's independent scan of this repo already passed on the listing PR, so this should be green from the first run.

## Supply-chain review (done before adopting)

- `contents: read` is the only permission; no secrets; checkout credentials not persisted.
- Both actions are pinned to commit SHAs (`actions/checkout` SHA verified as official v4.2.2).
- Inspected `hashgraph-online/ai-plugin-scanner-action` at the pinned commit: it downloads a version-pinned `plugin-scanner` wheel, verifies it against a committed SHA-256 **and** PyPI provenance attestations before installing; network probing, SARIF upload, and submission-issue automation are all off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)