### PR TITLE
docs(README): add Plugin Security Scan CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # l3a0's Claude Code plugins
 
+[![Plugin Security Scan](https://github.com/l3a0/claude-plugins/actions/workflows/plugin-security-scan.yml/badge.svg?branch=main)](https://github.com/l3a0/claude-plugins/actions/workflows/plugin-security-scan.yml)
+
 A personal collection of [Claude Code](https://code.claude.com) skills, published as a single
 plugin under the `l3a0` namespace. This repo is both the plugin and its own marketplace.
 


### PR DESCRIPTION
Adds the dynamic GitHub Actions badge for the Plugin Security Scan workflow (main branch) under the README title. Chose the live workflow badge over SCANNER_GUIDE.md's static "HOL Guard passing" shields badge, since the dynamic one reflects the actual latest scan result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)